### PR TITLE
Add Request class with body extractor

### DIFF
--- a/lib/Request.d.ts
+++ b/lib/Request.d.ts
@@ -1,0 +1,24 @@
+/*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*\
+
+  SVR: Simple HTTP(S) Server
+
+  Copyright (c) TypeScriptLibs and Contributors
+
+  Licensed under the MIT License; you may not use this file except in
+  compliance with the License. You may obtain a copy of the MIT License at
+  https://typescriptlibs.org/LICENSE.txt
+
+\*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*/
+/// <reference types="node" resolution-mode="require"/>
+import Server, { ServerInput, ServerOutput, ServerProtocol } from './Server.js';
+export declare class Request {
+    constructor(server: Server, output: ServerOutput);
+    private _body?;
+    readonly input: ServerInput;
+    readonly output: ServerOutput;
+    readonly protocol: ServerProtocol;
+    readonly server: Server;
+    readonly url: URL;
+    body(): Promise<Buffer>;
+}
+export default Request;

--- a/lib/Request.d.ts
+++ b/lib/Request.d.ts
@@ -10,13 +10,14 @@
 
 \*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*/
 /// <reference types="node" resolution-mode="require"/>
-import Server, { ServerInput, ServerOutput, ServerProtocol } from './Server.js';
+import Server, { ServerInput, ServerOutput } from './Server.js';
+export type RequestProtocol = ('http' | 'https');
 export declare class Request {
     constructor(server: Server, output: ServerOutput);
     private _body?;
     readonly input: ServerInput;
     readonly output: ServerOutput;
-    readonly protocol: ServerProtocol;
+    readonly protocol: RequestProtocol;
     readonly server: Server;
     readonly url: URL;
     body(): Promise<Buffer>;

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -1,0 +1,59 @@
+/*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*\
+
+  SVR: Simple HTTP(S) Server
+
+  Copyright (c) TypeScriptLibs and Contributors
+
+  Licensed under the MIT License; you may not use this file except in
+  compliance with the License. You may obtain a copy of the MIT License at
+  https://typescriptlibs.org/LICENSE.txt
+
+\*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*/
+import TLS from 'node:tls';
+/* *
+ *
+ *  Class
+ *
+ * */
+export class Request {
+    /* *
+     *
+     *  Constructor
+     *
+     * */
+    constructor(server, output) {
+        const input = output.req;
+        const protocol = (input.socket instanceof TLS.TLSSocket ? 'https' : 'http');
+        this.input = output.req;
+        this.output = output;
+        this.protocol = protocol;
+        this.server = server;
+        this.url = new URL((input.url || ''), `${protocol}://${input.headers.host}`);
+    }
+    /* *
+     *
+     *  Functions
+     *
+     * */
+    body() {
+        if (this._body) {
+            return Promise.resolve(this._body);
+        }
+        return new Promise((resolve, reject) => {
+            const input = this.input;
+            const chunks = [];
+            input.on('error', reject);
+            input.on('data', (chunk) => chunks.push(chunk));
+            input.on('end', () => {
+                this._body = Buffer.concat(chunks);
+                resolve(this._body);
+            });
+        });
+    }
+}
+/* *
+ *
+ *  Default Export
+ *
+ * */
+export default Request;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -10,5 +10,6 @@
 
 \*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*/
 export * from './ContentTypes.js';
+export * from './Request.js';
 export * from './Server.js';
 export * from './System.js';

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,5 +10,6 @@
 
 \*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*/
 export * from './ContentTypes.js';
+export * from './Request.js';
 export * from './Server.js';
 export * from './System.js';

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -20,9 +20,22 @@
 
 import HTTP from 'node:http';
 
-import Server, { ServerInput, ServerOutput, ServerProtocol } from './Server.js';
+import Server, { ServerInput, ServerOutput } from './Server.js';
 
 import TLS from 'node:tls';
+
+
+/* *
+ *
+ *  Declarations
+ *
+ * */
+
+
+export type RequestProtocol = (
+    | 'http'
+    | 'https'
+);
 
 
 /* *
@@ -47,7 +60,7 @@ export class Request {
         output: ServerOutput
     ) {
         const input: ServerInput = output.req;
-        const protocol = ( input.socket instanceof TLS.TLSSocket ? 'https' : 'http' );
+        const protocol: RequestProtocol = ( input.socket instanceof TLS.TLSSocket ? 'https' : 'http' );
 
         this.input = output.req;
         this.output = output;
@@ -70,7 +83,7 @@ export class Request {
 
     public readonly output: ServerOutput;
 
-    public readonly protocol: ServerProtocol;
+    public readonly protocol: RequestProtocol;
 
     public readonly server: Server;
 

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -1,0 +1,120 @@
+/*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*!*\
+
+  SVR: Simple HTTP(S) Server
+
+  Copyright (c) TypeScriptLibs and Contributors
+
+  Licensed under the MIT License; you may not use this file except in
+  compliance with the License. You may obtain a copy of the MIT License at
+  https://typescriptlibs.org/LICENSE.txt
+
+\*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*/
+
+
+/* *
+ *
+ *  Imports
+ *
+ * */
+
+
+import HTTP from 'node:http';
+
+import Server, { ServerInput, ServerOutput, ServerProtocol } from './Server.js';
+
+import TLS from 'node:tls';
+
+
+/* *
+ *
+ *  Class
+ *
+ * */
+
+
+export class Request {
+
+
+    /* *
+     *
+     *  Constructor
+     *
+     * */
+
+
+    public constructor (
+        server: Server,
+        output: ServerOutput
+    ) {
+        const input: ServerInput = output.req;
+        const protocol = ( input.socket instanceof TLS.TLSSocket ? 'https' : 'http' );
+
+        this.input = output.req;
+        this.output = output;
+        this.protocol = protocol;
+        this.server = server;
+        this.url = new URL( ( input.url || '' ), `${protocol}://${input.headers.host}` );
+    }
+
+
+    /* *
+     *
+     *  Properties
+     *
+     * */
+
+
+    private _body?: Buffer;
+
+    public readonly input: ServerInput;
+
+    public readonly output: ServerOutput;
+
+    public readonly protocol: ServerProtocol;
+
+    public readonly server: Server;
+
+    public readonly url: URL;
+
+
+    /* *
+     *
+     *  Functions
+     *
+     * */
+
+
+    public body (): Promise<Buffer> {
+
+        if ( this._body ) {
+            return Promise.resolve( this._body );
+        }
+
+        return new Promise( ( resolve, reject ) => {
+            const input = this.input;
+            const chunks: Array<Uint8Array> = [];
+
+            input.on( 'error', reject );
+
+            input.on( 'data', ( chunk: Uint8Array ) => chunks.push( chunk ) );
+
+            input.on( 'end', () => {
+                this._body = Buffer.concat( chunks );
+
+                resolve( this._body );
+            } );
+        } );
+    }
+
+
+}
+
+
+/* *
+ *
+ *  Default Export
+ *
+ * */
+
+
+export default Request;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,5 +11,6 @@
 \*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*i*/
 
 export * from './ContentTypes.js';
+export * from './Request.js';
 export * from './Server.js';
 export * from './System.js';


### PR DESCRIPTION
Add `Request` class
- combines context properties
- provides an extractor function for the HTTP body (`POST`/`PUT`)