### PR TITLE
File content of TLS certificate is now used for HTTPS.

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -121,10 +121,18 @@ export class CLI {
             }
         }
         if (args['https-cert']) {
-            options.httpsCert = args['https-cert'].toString();
+            const certPath = args['https-cert'].toString();
+            if (System.fileExists(certPath)) {
+                // set file content, not path (#1)
+                options.httpsCert = System.fileContent(certPath);
+            }
         }
         if (args['https-key']) {
-            options.httpsCert = args['https-key'].toString();
+            const keyPath = args['https-key'].toString();
+            if (System.fileExists(keyPath)) {
+                // set file content, not path (#1)
+                options.httpsKey = System.fileContent(keyPath);
+            }
         }
         if (args.typescript) {
             options.typeScript = true;

--- a/src/CLI.ts
+++ b/src/CLI.ts
@@ -181,11 +181,21 @@ export class CLI {
         }
 
         if ( args['https-cert'] ) {
-            options.httpsCert = args['https-cert'].toString();
+            const certPath = args['https-cert'].toString();
+
+            if ( System.fileExists( certPath ) ) {
+                // set file content, not path (#1)
+                options.httpsCert = System.fileContent( certPath );
+            }
         }
 
         if ( args['https-key'] ) {
-            options.httpsCert = args['https-key'].toString();
+            const keyPath = args['https-key'].toString();
+
+            if ( System.fileExists( keyPath ) ) {
+                // set file content, not path (#1)
+                options.httpsKey = System.fileContent( keyPath );
+            }
         }
 
         if ( args.typescript ) {


### PR DESCRIPTION
Fix #1; TLS certificate not loaded. File content of TLS certificate is now used for HTTPS.